### PR TITLE
Add structured output formats and streaming to all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A CLI for on-device speech transcription using [Speech.framework](https://develo
 ### Usage
 
 ```
-USAGE: yap transcribe [--locale <locale>] [--censor] <input-file> [--txt] [--srt] [--output-file <output-file>]
+USAGE: yap transcribe [--locale <locale>] [--censor] <input-file> [--txt] [--srt] [--vtt] [--json] [--output-file <output-file>] [--max-length <max-length>] [--word-timestamps]
 
 ARGUMENTS:
   <input-file>            Path to an audio or video file to transcribe.
@@ -15,10 +15,14 @@ ARGUMENTS:
 OPTIONS:
   -l, --locale <locale>   (default: current)
   --censor                Replaces certain words and phrases with a redacted form.
-  --txt/--srt             Output format for the transcription. (default: --txt)
+  --txt/--srt/--vtt/--json
+                          Output format for the transcription. (default: --txt)
   -o, --output-file <output-file>
                           Path to save the transcription output. If not provided,
                           output will be printed to stdout.
+  -m, --max-length <max-length>
+                          Maximum sentence length in characters. (default: 40)
+  --word-timestamps       Include word-level timestamps in JSON output.
   -h, --help              Show help information.
 ```
 
@@ -56,16 +60,34 @@ yap video.mp4 | uvx llm -m mlx-community/Llama-3.2-1B-Instruct-4bit 'Summarize t
 yap video.mp4 --srt -o captions.srt
 ```
 
+#### Generate WebVTT subtitles
+
+```bash
+yap video.mp4 --vtt -o subtitles.vtt
+```
+
+#### Export JSON with word-level timestamps
+
+```bash
+yap video.mp4 --json --word-timestamps -o transcript.json
+```
+
 ### Live System Audio
 
 `yap listen` transcribes system audio in real time — anything playing on your computer.
 
 ```
-USAGE: yap listen [--locale <locale>] [--censor]
+USAGE: yap listen [--locale <locale>] [--censor] [--txt] [--srt] [--vtt] [--json] [--max-length <max-length>] [--word-timestamps]
 
 OPTIONS:
   -l, --locale <locale>   (default: current)
   --censor                Replaces certain words and phrases with a redacted form.
+  --txt/--srt/--vtt/--json
+                          Output format for the transcription. (default: --txt)
+  -m, --max-length <max-length>
+                          Maximum sentence length in characters for timed output
+                          formats. (default: 40)
+  --word-timestamps       Include word-level timestamps in JSON output.
   -h, --help              Show help information.
 ```
 
@@ -79,6 +101,9 @@ yap listen
 
 # Pipe live transcription to another tool
 yap listen | uvx llm 'Translate this to French:'
+
+# Save system audio as VTT subtitles
+yap listen --vtt > captions.vtt
 ```
 
 ### Listen and Dictate
@@ -86,11 +111,22 @@ yap listen | uvx llm 'Translate this to French:'
 `yap listen-and-dictate` transcribes both system audio and microphone input simultaneously — perfect for meeting transcription.
 
 ```
-USAGE: yap listen-and-dictate [--locale <locale>] [--censor]
+USAGE: yap listen-and-dictate [--locale <locale>] [--censor] [--txt] [--srt] [--vtt] [--json] [--max-length <max-length>] [--mic-label <mic-label>] [--system-label <system-label>] [--word-timestamps]
 
 OPTIONS:
   -l, --locale <locale>   (default: current)
   --censor                Replaces certain words and phrases with a redacted form.
+  --txt/--srt/--vtt/--json
+                          Output format for the transcription. (default: --txt)
+  -m, --max-length <max-length>
+                          Maximum sentence length in characters for timed output
+                          formats. (default: 40)
+  --mic-label <mic-label> Speaker label for microphone audio in timed output
+                          formats. (default: Mic)
+  --system-label <system-label>
+                          Speaker label for system audio in timed output
+                          formats. (default: System)
+  --word-timestamps       Include word-level timestamps in JSON output.
   -h, --help              Show help information.
 ```
 
@@ -104,6 +140,12 @@ yap listen-and-dictate
 
 # Save a meeting transcript
 yap listen-and-dictate > meeting.txt
+
+# Save a meeting transcript as VTT with speaker labels
+yap listen-and-dictate --vtt > meeting.vtt
+
+# Use custom speaker labels
+yap listen-and-dictate --vtt --mic-label Alice --system-label Bob > meeting.vtt
 ```
 
 ### Dictation
@@ -111,11 +153,17 @@ yap listen-and-dictate > meeting.txt
 `yap dictate` transcribes microphone input in real time.
 
 ```
-USAGE: yap dictate [--locale <locale>] [--censor]
+USAGE: yap dictate [--locale <locale>] [--censor] [--txt] [--srt] [--vtt] [--json] [--max-length <max-length>] [--word-timestamps]
 
 OPTIONS:
   -l, --locale <locale>   (default: current)
   --censor                Replaces certain words and phrases with a redacted form.
+  --txt/--srt/--vtt/--json
+                          Output format for the transcription. (default: --txt)
+  -m, --max-length <max-length>
+                          Maximum sentence length in characters for timed output
+                          formats. (default: 40)
+  --word-timestamps       Include word-level timestamps in JSON output.
   -h, --help              Show help information.
 ```
 

--- a/Sources/yap/Dictate.swift
+++ b/Sources/yap/Dictate.swift
@@ -22,6 +22,19 @@ struct Dictate: AsyncParsableCommand {
         help: "Replaces certain words and phrases with a redacted form."
     ) var censor: Bool = false
 
+    @Flag(
+        help: "Output format for the transcription."
+    ) var outputFormat: OutputFormat = .txt
+
+    @Option(
+        name: .shortAndLong,
+        help: "Maximum sentence length in characters for timed output formats."
+    ) var maxLength: Int = 40
+
+    @Flag(
+        help: "Include word-level timestamps in JSON output."
+    ) var wordTimestamps: Bool = false
+
     @MainActor mutating func run() async throws {
         guard SpeechTranscriber.isAvailable else {
             throw Transcribe.Error.speechTranscriberNotAvailable
@@ -41,7 +54,7 @@ struct Dictate: AsyncParsableCommand {
             locale: locale,
             transcriptionOptions: censor ? [.etiquetteReplacements] : [],
             reportingOptions: [],
-            attributeOptions: []
+            attributeOptions: outputFormat.needsAudioTimeRange ? [.audioTimeRange] : []
         )
         let modules: [any SpeechModule] = [transcriber]
 
@@ -137,30 +150,61 @@ struct Dictate: AsyncParsableCommand {
             try? await analyzer.finalizeAndFinishThroughEndOfInput()
         }
 
-        // Print results as they arrive
-        for try await result in transcriber.results {
-            let text = String(result.text.characters)
-            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                print(text, terminator: "")
-                fflush(stdout)
+        // Stream results as they arrive
+        let format = outputFormat
+        let sentenceMaxLength = maxLength
+        if format == .txt {
+            for try await result in transcriber.results {
+                let text = String(result.text.characters)
+                if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    print(text, terminator: "")
+                    fflush(stdout)
+                }
+            }
+            print()
+        } else {
+            if let header = format.header(locale: locale) {
+                print(header)
+            }
+            let includeWords = wordTimestamps
+            var segmentIndex = 0
+            for try await result in transcriber.results {
+                for chunk in result.text.splitAtTimeGaps(threshold: 1.5) {
+                    let allWords = includeWords ? chunk.wordTimestamps() : nil
+                    for sentence in chunk.sentences(maxLength: sentenceMaxLength) {
+                        guard let timeRange = sentence.audioTimeRange else { continue }
+                        let text = String(sentence.characters).trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !text.isEmpty else { continue }
+                        let words = allWords?.filter {
+                            $0.timeRange.start.seconds >= timeRange.start.seconds
+                                && $0.timeRange.end.seconds <= timeRange.end.seconds
+                        }
+                        if segmentIndex > 0, let sep = format.segmentSeparator {
+                            print(sep, terminator: "")
+                        }
+                        segmentIndex += 1
+                        print(format.formatSegment(index: segmentIndex, timeRange: timeRange, text: text, words: words), terminator: "")
+                        fflush(stdout)
+                    }
+                }
+            }
+            if segmentIndex > 0 { print() }
+            if let footer = format.footer {
+                print(footer)
             }
         }
-        print()
     }
 }
 
 // MARK: - MicrophoneCapture
 
 final class MicrophoneCapture: @unchecked Sendable {
-    let audioEngine: AVAudioEngine
-    let converter: AVAudioConverter
-    let inputContinuation: AsyncStream<AnalyzerInput>.Continuation
-    let targetFormat: AVAudioFormat
+    // MARK: Lifecycle
 
     init(targetFormat: AVAudioFormat, inputContinuation: AsyncStream<AnalyzerInput>.Continuation) throws {
         self.targetFormat = targetFormat
         self.inputContinuation = inputContinuation
-        self.audioEngine = AVAudioEngine()
+        audioEngine = AVAudioEngine()
 
         let inputNode = audioEngine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
@@ -179,6 +223,13 @@ final class MicrophoneCapture: @unchecked Sendable {
         }
     }
 
+    // MARK: Internal
+
+    let audioEngine: AVAudioEngine
+    let converter: AVAudioConverter
+    let inputContinuation: AsyncStream<AnalyzerInput>.Continuation
+    let targetFormat: AVAudioFormat
+
     func stop() {
         audioEngine.stop()
         inputContinuation.finish()
@@ -191,6 +242,8 @@ final class MicrophoneCapture: @unchecked Sendable {
             throw DictateError.microphonePermissionDenied
         }
     }
+
+    // MARK: Private
 
     private func handleBuffer(_ buffer: AVAudioPCMBuffer) {
         let frameCapacity = AVAudioFrameCount(

--- a/Sources/yap/Extensions/AttributedString+Extensions.swift
+++ b/Sources/yap/Extensions/AttributedString+Extensions.swift
@@ -3,6 +3,53 @@ import Foundation
 import NaturalLanguage
 
 extension AttributedString {
+    func wordTimestamps() -> [(text: String, timeRange: CMTimeRange)] {
+        let tokenizer = NLTokenizer(unit: .word)
+        let string = String(characters)
+        tokenizer.string = string
+        return tokenizer.tokens(for: string.startIndex..<string.endIndex).compactMap { wordRange in
+            guard let attrStart = AttributedString.Index(wordRange.lowerBound, within: self),
+                  let attrEnd = AttributedString.Index(wordRange.upperBound, within: self) else { return nil }
+            let wordSlice = self[attrStart..<attrEnd]
+            let text = String(wordSlice.characters).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            let timeRanges = wordSlice.runs.compactMap(\.audioTimeRange)
+            guard let first = timeRanges.first, let last = timeRanges.last else { return nil }
+            return (text, CMTimeRange(start: first.start, end: last.end))
+        }
+    }
+
+    /// Split this attributed string at points where consecutive timed runs have
+    /// a gap exceeding the given threshold. This prevents merging segments that
+    /// are separated by a long pause (e.g. another speaker talking in between).
+    func splitAtTimeGaps(threshold: TimeInterval) -> [AttributedString] {
+        var splitPoints: [AttributedString.Index] = []
+        var previousEndTime: TimeInterval?
+        for run in runs {
+            guard let timeRange = run.audioTimeRange else { continue }
+            let text = String(self[run.range].characters)
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { continue }
+            if let prevEnd = previousEndTime,
+               timeRange.start.seconds - prevEnd > threshold {
+                splitPoints.append(run.range.lowerBound)
+            }
+            previousEndTime = timeRange.end.seconds
+        }
+        guard !splitPoints.isEmpty else { return [self] }
+        var pieces: [AttributedString] = []
+        var start = startIndex
+        for point in splitPoints {
+            if start < point {
+                pieces.append(AttributedString(self[start..<point]))
+            }
+            start = point
+        }
+        if start < endIndex {
+            pieces.append(AttributedString(self[start..<endIndex]))
+        }
+        return pieces
+    }
+
     func sentences(maxLength: Int? = nil) -> [AttributedString] {
         let tokenizer = NLTokenizer(unit: .sentence)
         let string = String(characters)

--- a/Sources/yap/MCP.swift
+++ b/Sources/yap/MCP.swift
@@ -35,18 +35,23 @@ struct MCP_Command: AsyncParsableCommand {
                             ]),
                             "format": .object([
                                 "type": "string",
-                                "description": "Output format: \"txt\" or \"srt\".",
+                                "description": "Output format: \"txt\", \"srt\", \"vtt\", or \"json\".",
                                 "default": "txt",
-                                "enum": .array(["txt", "srt"]),
+                                "enum": .array(["txt", "srt", "vtt", "json"]),
                             ]),
                             "maxLength": .object([
                                 "type": "integer",
-                                "description": "Maximum sentence length in characters for SRT output.",
+                                "description": "Maximum sentence length in characters for timed output formats.",
                                 "default": 40,
                             ]),
                             "censor": .object([
                                 "type": "boolean",
                                 "description": "Replace certain words with a redacted form.",
+                                "default": false,
+                            ]),
+                            "wordTimestamps": .object([
+                                "type": "boolean",
+                                "description": "Include word-level timestamps in JSON output.",
                                 "default": false,
                             ]),
                         ]),
@@ -74,6 +79,8 @@ struct MCP_Command: AsyncParsableCommand {
             if let format = request.arguments?["format"]?.stringValue {
                 switch format {
                 case "srt": options.outputFormat = .srt
+                case "vtt": options.outputFormat = .vtt
+                case "json": options.outputFormat = .json
                 default: options.outputFormat = .txt
                 }
             }
@@ -84,6 +91,10 @@ struct MCP_Command: AsyncParsableCommand {
 
             if let censor = request.arguments?["censor"]?.boolValue {
                 options.censor = censor
+            }
+
+            if let wordTimestamps = request.arguments?["wordTimestamps"]?.boolValue {
+                options.wordTimestamps = wordTimestamps
             }
 
             do {

--- a/Sources/yap/OutputFormat.swift
+++ b/Sources/yap/OutputFormat.swift
@@ -5,42 +5,250 @@ import Foundation
 enum OutputFormat: String, EnumerableFlag {
     case txt
     case srt
+    case vtt
+    case json
 
     // MARK: Internal
 
+    struct Segment {
+        var timeRange: CMTimeRange
+        var text: String
+        var speaker: String?
+        var words: [(text: String, timeRange: CMTimeRange)]?
+    }
+
     var needsAudioTimeRange: Bool {
         switch self {
-        case .srt: true
-        default: false
+        case .txt: false
+        case .srt, .vtt, .json: true
         }
     }
 
-    func text(for transcript: AttributedString, maxLength: Int) -> String {
+    /// Separator string between consecutive streaming segments, if any.
+    var segmentSeparator: String? {
+        switch self {
+        case .srt, .vtt: "\n\n"
+        case .json: ",\n"
+        case .txt: nil
+        }
+    }
+
+    /// Footer to print after all segments (closes the JSON structure).
+    var footer: String? {
+        switch self {
+        case .json: "  ]\n}"
+        default: nil
+        }
+    }
+
+    // MARK: Streaming API (used by live commands)
+
+    /// Header to print once before any segments.
+    func header(locale: Locale? = nil, speakers: Set<String> = []) -> String? {
+        switch self {
+        case .vtt:
+            return Self.vttHeader(speakers: speakers) + "\n"
+        case .json:
+            var metadata: [String: Any] = [:]
+            if let locale {
+                metadata["language"] = locale.identifier(.bcp47)
+            }
+            if !speakers.isEmpty {
+                metadata["speakers"] = speakers.sorted()
+            }
+            metadata["created"] = ISO8601DateFormatter().string(from: Date())
+            guard let data = try? JSONSerialization.data(withJSONObject: metadata, options: [.prettyPrinted, .sortedKeys]),
+                  let metadataStr = String(data: data, encoding: .utf8) else {
+                return "{\n  \"metadata\" : {},\n  \"segments\" : ["
+            }
+            let indented = metadataStr.components(separatedBy: "\n").enumerated()
+                .map { $0.offset == 0 ? $0.element : "  " + $0.element }
+                .joined(separator: "\n")
+            return "{\n  \"metadata\" : \(indented),\n  \"segments\" : ["
+        default:
+            return nil
+        }
+    }
+
+    /// Format a single segment for immediate streaming output.
+    /// - For SRT: numbered block with optional `Speaker: text` prefix
+    /// - For VTT: numbered cue with optional `<v Speaker>text` voice tag
+    /// - For JSON: single segment object
+    func formatSegment(
+        index: Int,
+        timeRange: CMTimeRange,
+        text: String,
+        speaker: String? = nil,
+        words: [(text: String, timeRange: CMTimeRange)]? = nil
+    ) -> String {
         switch self {
         case .txt:
-            return String(transcript.characters)
+            return text
         case .srt:
-            func format(_ timeInterval: TimeInterval) -> String {
-                let ms = Int(timeInterval.truncatingRemainder(dividingBy: 1) * 1000)
-                let s = Int(timeInterval) % 60
-                let m = (Int(timeInterval) / 60) % 60
-                let h = Int(timeInterval) / 60 / 60
-                return String(format: "%0.2d:%0.2d:%0.2d,%0.3d", h, m, s, ms)
+            let content = speaker.map { "\($0): \(text)" } ?? text
+            return "\(index)\n\(Self.srtTime(timeRange.start.seconds)) --> \(Self.srtTime(timeRange.end.seconds))\n\(content)"
+        case .vtt:
+            let content = speaker.map { "<v \($0)>\(text)" } ?? text
+            return "\(index)\n\(Self.vttTime(timeRange.start.seconds)) --> \(Self.vttTime(timeRange.end.seconds))\n\(content)"
+        case .json:
+            var dict: [String: Any] = [
+                "id": index,
+                "start": Self.jsonTime(timeRange.start.seconds),
+                "end": Self.jsonTime(timeRange.end.seconds),
+                "text": text,
+            ]
+            if let speaker { dict["speaker"] = speaker }
+            if let words {
+                dict["words"] = words.map { word in
+                    [
+                        "text": word.text,
+                        "start": Self.jsonTime(word.timeRange.start.seconds),
+                        "end": Self.jsonTime(word.timeRange.end.seconds),
+                    ] as [String: Any]
+                }
             }
-
-            return transcript.sentences(maxLength: maxLength).compactMap { (sentence: AttributedString) -> (CMTimeRange, String)? in
-                guard let timeRange = sentence.audioTimeRange else { return nil }
-                return (timeRange, String(sentence.characters))
-            }.enumerated().map { index, run in
-                let (timeRange, text) = run
-                return """
-
-                \(index + 1)
-                \(format(timeRange.start.seconds)) --> \(format(timeRange.end.seconds))
-                \(text.trimmingCharacters(in: .whitespacesAndNewlines))
-
-                """
-            }.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+            if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys]),
+               let str = String(data: data, encoding: .utf8) {
+                return str.components(separatedBy: "\n").map { "    " + $0 }.joined(separator: "\n")
+            }
+            return "    {}"
         }
+    }
+
+    // MARK: Buffered API (used by transcribe command)
+
+    func text(
+        for transcript: AttributedString,
+        maxLength: Int,
+        speakerLabel: String? = nil,
+        locale: Locale? = nil,
+        wordTimestamps: Bool = false
+    ) -> String {
+        if self == .txt {
+            return String(transcript.characters)
+        }
+        let allWords = wordTimestamps ? transcript.wordTimestamps() : nil
+        let segments: [Segment] = transcript
+            .sentences(maxLength: maxLength)
+            .compactMap { sentence in
+                guard let timeRange = sentence.audioTimeRange else { return nil }
+                let words = allWords?.filter {
+                    $0.timeRange.start.seconds >= timeRange.start.seconds
+                        && $0.timeRange.end.seconds <= timeRange.end.seconds
+                }
+                return Segment(
+                    timeRange: timeRange,
+                    text: String(sentence.characters).trimmingCharacters(in: .whitespacesAndNewlines),
+                    speaker: speakerLabel,
+                    words: words
+                )
+            }
+        return formatSegments(segments, locale: locale)
+    }
+
+    func formatSegments(
+        _ segments: [Segment],
+        locale: Locale? = nil
+    ) -> String {
+        switch self {
+        case .txt:
+            return segments.map(\.text).joined(separator: " ")
+        case .srt:
+            return segments.enumerated().map { i, seg in
+                formatSegment(index: i + 1, timeRange: seg.timeRange, text: seg.text, speaker: seg.speaker)
+            }.joined(separator: "\n\n")
+        case .vtt:
+            let speakers = Set(segments.compactMap(\.speaker))
+            return ([Self.vttHeader(speakers: speakers)] + segments.enumerated().map { i, seg in
+                formatSegment(index: i + 1, timeRange: seg.timeRange, text: seg.text, speaker: seg.speaker)
+            }).joined(separator: "\n\n")
+        case .json:
+            return formatJSON(segments, locale: locale)
+        }
+    }
+
+    // MARK: Private
+
+    /// Round a time interval to millisecond precision using Decimal to avoid
+    /// floating-point artifacts like 2.2200000000000002 in JSON output.
+    private static func jsonTime(_ t: TimeInterval) -> Decimal {
+        Decimal(Int(round(t * 1000))) / 1000
+    }
+
+    private static func vttHeader(speakers: Set<String> = []) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd 'at' HH:mm:ss"
+        var header = "WEBVTT\n\nNOTE\nThis transcript was created on \(formatter.string(from: Date()))"
+        if !speakers.isEmpty {
+            header += "\nSpeakers: \(speakers.sorted().joined(separator: ", "))"
+        }
+        return header
+    }
+
+    private static func srtTime(_ t: TimeInterval) -> String {
+        let ms = Int(t.truncatingRemainder(dividingBy: 1) * 1000)
+        let s = Int(t) % 60
+        let m = (Int(t) / 60) % 60
+        let h = Int(t) / 60 / 60
+        return String(format: "%0.2d:%0.2d:%0.2d,%0.3d", h, m, s, ms)
+    }
+
+    private static func vttTime(_ t: TimeInterval) -> String {
+        let ms = Int(t.truncatingRemainder(dividingBy: 1) * 1000)
+        let s = Int(t) % 60
+        let m = (Int(t) / 60) % 60
+        let h = Int(t) / 60 / 60
+        return String(format: "%0.2d:%0.2d:%0.2d.%0.3d", h, m, s, ms)
+    }
+
+    private func formatJSON(
+        _ segments: [Segment],
+        locale: Locale?
+    ) -> String {
+        var metadata: [String: Any] = [:]
+        if let maxEnd = segments.map(\.timeRange.end.seconds).max() {
+            metadata["duration"] = Self.jsonTime(maxEnd)
+        }
+        if let locale {
+            metadata["language"] = locale.identifier(.bcp47)
+        }
+        let speakers = Set(segments.compactMap(\.speaker))
+        if !speakers.isEmpty {
+            metadata["speakers"] = speakers.sorted()
+        }
+        metadata["created"] = ISO8601DateFormatter().string(from: Date())
+
+        let segmentDicts: [[String: Any]] = segments.enumerated().map { index, segment in
+            var dict: [String: Any] = [
+                "id": index + 1,
+                "start": Self.jsonTime(segment.timeRange.start.seconds),
+                "end": Self.jsonTime(segment.timeRange.end.seconds),
+                "text": segment.text,
+            ]
+            if let speaker = segment.speaker {
+                dict["speaker"] = speaker
+            }
+            if let words = segment.words {
+                dict["words"] = words.map { word in
+                    [
+                        "text": word.text,
+                        "start": Self.jsonTime(word.timeRange.start.seconds),
+                        "end": Self.jsonTime(word.timeRange.end.seconds),
+                    ] as [String: Any]
+                }
+            }
+            return dict
+        }
+
+        let json: [String: Any] = [
+            "metadata": metadata,
+            "segments": segmentDicts,
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
     }
 }

--- a/Sources/yap/TranscriptionEngine.swift
+++ b/Sources/yap/TranscriptionEngine.swift
@@ -9,6 +9,7 @@ enum TranscriptionEngine {
         var censor: Bool = false
         var outputFormat: OutputFormat = .txt
         var maxLength: Int = 40
+        var wordTimestamps: Bool = false
     }
 
     static func transcribe(
@@ -57,7 +58,7 @@ enum TranscriptionEngine {
             transcript += result.text
         }
 
-        return options.outputFormat.text(for: transcript, maxLength: options.maxLength)
+        return options.outputFormat.text(for: transcript, maxLength: options.maxLength, locale: options.locale, wordTimestamps: options.wordTimestamps)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add VTT, JSON, and SRT output formats to `listen`, `dictate`, and `listen-and-dictate` (previously only `transcribe` had SRT)
- Stream segments to stdout immediately as they arrive instead of buffering until shutdown
- JSON output includes metadata (language, speakers, created timestamp) with optional `--word-timestamps` flag for per-word timing
- VTT output includes a NOTE block with creation date and speaker list
- `listen-and-dictate` gets `--mic-label` / `--system-label` options for customizable speaker attribution
- Split transcriber results at significant time gaps (>1.5s) so segments separated by another speaker talking are output separately
- Update MCP tool schema with new format options and word timestamp parameter
- OSC 9;4 terminal progress updates