### PR TITLE
Handle nilError by chunking transcription

### DIFF
--- a/Sources/yap/Transcribe.swift
+++ b/Sources/yap/Transcribe.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import ArgumentParser
 import NaturalLanguage
 @preconcurrency import Noora
@@ -83,36 +84,123 @@ import Speech
                 }
             }
         }
+        func isNilError(_ error: Swift.Error) -> Bool {
+            if String(describing: error) == "nilError" {
+                return true
+            }
+            let nsError = error as NSError
+            return nsError.domain == "Foundation._GenericObjCError" && nsError.code == 0
+        }
 
-        let analyzer = SpeechAnalyzer(modules: modules)
+        func offsetAudioTimeRanges(in transcript: AttributedString, by offset: TimeInterval) -> AttributedString {
+            guard outputFormat.needsAudioTimeRange, offset != 0 else { return transcript }
+            var adjusted = transcript
+            let offsetTime = CMTime(seconds: offset, preferredTimescale: 600)
+            for run in adjusted.runs {
+                guard let timeRange = run.audioTimeRange else { continue }
+                let start = CMTimeAdd(timeRange.start, offsetTime)
+                let end = CMTimeAdd(timeRange.end, offsetTime)
+                adjusted[run.range].audioTimeRange = CMTimeRange(start: start, end: end)
+            }
+            return adjusted
+        }
 
-        let audioFile = try AVAudioFile(forReading: inputFile)
-        let audioFileDuration: TimeInterval = Double(audioFile.length) / audioFile.processingFormat.sampleRate
-        try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
+        func transcribeFile(_ fileURL: URL, label: String? = nil, timeOffset: TimeInterval = 0) async throws -> AttributedString {
+            let transcriber = SpeechTranscriber(
+                locale: locale,
+                transcriptionOptions: censor ? [.etiquetteReplacements] : [],
+                reportingOptions: [],
+                attributeOptions: outputFormat.needsAudioTimeRange ? [.audioTimeRange] : []
+            )
+            let analyzer = SpeechAnalyzer(modules: [transcriber])
+            let audioFile = try AVAudioFile(forReading: fileURL)
+            let audioFileDuration: TimeInterval = Double(audioFile.length) / audioFile.processingFormat.sampleRate
+            try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
 
-        var transcript: AttributedString = ""
+            var transcript: AttributedString = ""
+            let labelSuffix = label.map { " (\($0))" } ?? ""
 
-        var w = winsize()
-        let terminalColumns = if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 {
-            max(Int(w.ws_col), 9)
-        } else { 64 }
+            var w = winsize()
+            let terminalColumns = if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 {
+                max(Int(w.ws_col), 9)
+            } else { 64 }
 
-        try await noora.progressStep(
-            message: "Transcribing audio using locale: \"\(locale.identifier)\"…",
-            successMessage: "Audio transcribed using locale: \"\(locale.identifier)\"",
-            errorMessage: "Failed to transcribe audio using locale: \"\(locale.identifier)\"",
-            showSpinner: true
-        ) { @Sendable progressHandler in
-            for try await result in transcriber.results {
-                await MainActor.run {
-                    transcript += result.text
+            try await noora.progressStep(
+                message: "Transcribing audio\(labelSuffix) using locale: \"\(locale.identifier)\"…",
+                successMessage: "Audio transcribed\(labelSuffix) using locale: \"\(locale.identifier)\"",
+                errorMessage: "Failed to transcribe audio\(labelSuffix) using locale: \"\(locale.identifier)\"",
+                showSpinner: true
+            ) { @Sendable progressHandler in
+                for try await result in transcriber.results {
+                    await MainActor.run {
+                        transcript += result.text
+                    }
+                    let progress = max(min(result.resultsFinalizationTime.seconds / audioFileDuration, 1), 0)
+                    var percent = progress.formatted(.percent.precision(.fractionLength(0)))
+                    let oneHundredPercent = 1.0.formatted(.percent.precision(.fractionLength(0)))
+                    percent = String(String(repeating: " ", count: max(oneHundredPercent.count - percent.count, 0))) + percent
+                    let message = "[\(percent)] \(String(result.text.characters).trimmingCharacters(in: .whitespaces).prefix(terminalColumns - "⠋ [\(oneHundredPercent)] ".count))"
+                    progressHandler(message)
                 }
-                let progress = max(min(result.resultsFinalizationTime.seconds / audioFileDuration, 1), 0)
-                var percent = progress.formatted(.percent.precision(.fractionLength(0)))
-                let oneHundredPercent = 1.0.formatted(.percent.precision(.fractionLength(0)))
-                percent = String(String(repeating: " ", count: max(oneHundredPercent.count - percent.count, 0))) + percent
-                let message = "[\(percent)] \(String(result.text.characters).trimmingCharacters(in: .whitespaces).prefix(terminalColumns - "⠋ [\(oneHundredPercent)] ".count))"
-                progressHandler(message)
+            }
+
+            return offsetAudioTimeRanges(in: transcript, by: timeOffset)
+        }
+
+        func exportChunk(from asset: AVAsset, timeRange: CMTimeRange, to outputURL: URL) async throws {
+            if FileManager.default.fileExists(atPath: outputURL.path) {
+                try FileManager.default.removeItem(at: outputURL)
+            }
+            guard let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
+                throw Error.audioExportSessionUnavailable
+            }
+            exportSession.timeRange = timeRange
+            try await exportSession.export(to: outputURL, as: .m4a)
+        }
+
+        func transcribeInChunks(from fileURL: URL) async throws -> AttributedString {
+            let asset = AVURLAsset(url: fileURL)
+            let duration = try await asset.load(.duration)
+            let totalSeconds = duration.seconds
+            let chunkDuration: TimeInterval = 30 * 60
+            let chunkCount = Int(ceil(totalSeconds / chunkDuration))
+            var transcript: AttributedString = ""
+            var chunkIndex = 1
+            var startSeconds: TimeInterval = 0
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("yap-chunks-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            while startSeconds < totalSeconds {
+                let endSeconds = min(startSeconds + chunkDuration, totalSeconds)
+                let preferredScale = duration.timescale == 0 ? CMTimeScale(600) : duration.timescale
+                let startTime = CMTime(seconds: startSeconds, preferredTimescale: preferredScale)
+                let endTime = CMTime(seconds: endSeconds, preferredTimescale: preferredScale)
+                let timeRange = CMTimeRange(start: startTime, end: endTime)
+                let chunkURL = tempDir.appendingPathComponent("chunk-\(chunkIndex).m4a")
+                try await exportChunk(from: asset, timeRange: timeRange, to: chunkURL)
+                let chunkTranscript = try await transcribeFile(
+                    chunkURL,
+                    label: "chunk \(chunkIndex)/\(chunkCount)",
+                    timeOffset: startSeconds
+                )
+                transcript += chunkTranscript
+                startSeconds = endSeconds
+                chunkIndex += 1
+            }
+
+            return transcript
+        }
+
+        let transcript: AttributedString
+        do {
+            transcript = try await transcribeFile(inputFile)
+        } catch {
+            if isNilError(error) {
+                noora.error(.alert("Speech framework returned nilError; retrying in chunks…"))
+                transcript = try await transcribeInChunks(from: inputFile)
+            } else {
+                throw error
             }
         }
 
@@ -135,6 +223,7 @@ import Speech
 
 extension Transcribe {
     enum Error: Swift.Error {
+        case audioExportSessionUnavailable
         case unsupportedLocale
     }
 }


### PR DESCRIPTION
This is a fully Codex-written patch which addresses a `nilError` I would frequently (and reproduceably) get on long files. I've been running this patched version on my machine for months now and processed ~100 files (mostly podcast episodes from a variety of shows), for unitof/overcast-favorites-archiver, and so far it has not introduced any new issues and fixes the long file bug.

I'm submitting this as a draft for now as I want to find and upload a few reproduceable tests, **and** confirm that the transcripts themselves do not suffer duplicated or omitted lines due to this fix (I have not looked closely, I am just transcribing for quick keyword text searchability right now).

Don't hesitate to ping me if I seem to forget, or tack on suggestions.

Co-authored-by: Codex (gpt-5.2-codex high) <codex@openai.com>
