### PR TITLE
Fix transcription hang, crash, and audio format errors

### DIFF
--- a/Sources/yap/AudioExtractor.swift
+++ b/Sources/yap/AudioExtractor.swift
@@ -1,0 +1,87 @@
+@preconcurrency import AVFoundation
+
+// MARK: - AudioExtractor
+
+enum AudioExtractor {
+    static func extractAudio(from asset: AVURLAsset, to outputURL: URL) async throws {
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+        guard let audioTrack = audioTracks.first else {
+            throw Error.noAudioTrack
+        }
+
+        // SpeechAnalyzer requires uncompressed PCM — M4A/AAC from AVAssetExportSession
+        // produces avfaudio error -50 (kAudio_ParamError). Use AVAssetReader/Writer to
+        // transcode directly to 16-bit mono 16 kHz Linear PCM WAV.
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+            AVSampleRateKey: 16000,
+            AVNumberOfChannelsKey: 1,
+        ]
+
+        let reader = try AVAssetReader(asset: asset)
+        let readerOutput = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: settings)
+        reader.add(readerOutput)
+
+        let writer = try AVAssetWriter(url: outputURL, fileType: .wav)
+        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: settings)
+        writer.add(writerInput)
+
+        reader.startReading()
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        // AVAssetWriter/AVAssetWriterInput/AVAssetReaderTrackOutput don't formally adopt
+        // Sendable, but are safe to use from a dispatch queue.
+        struct Context: @unchecked Sendable {
+            let writerInput: AVAssetWriterInput
+            let readerOutput: AVAssetReaderTrackOutput
+            let writer: AVAssetWriter
+        }
+        let ctx = Context(writerInput: writerInput, readerOutput: readerOutput, writer: writer)
+
+        // Use a serial queue: requestMediaDataWhenReady can fire the callback multiple
+        // times on a concurrent queue, causing a race where finishWriting is called twice
+        // (crash: "Cannot call method when status is 1").
+        let queue = DispatchQueue(label: "yap.audio-extractor")
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Swift.Error>) in
+            ctx.writerInput.requestMediaDataWhenReady(on: queue) {
+                while ctx.writerInput.isReadyForMoreMediaData {
+                    if let buffer = ctx.readerOutput.copyNextSampleBuffer() {
+                        ctx.writerInput.append(buffer)
+                    } else {
+                        ctx.writerInput.markAsFinished()
+                        ctx.writer.finishWriting {
+                            if ctx.writer.status == .completed {
+                                continuation.resume()
+                            } else {
+                                continuation.resume(throwing: ctx.writer.error ?? Error.failed)
+                            }
+                        }
+                        return
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: AudioExtractor.Error
+
+extension AudioExtractor {
+    enum Error: Swift.Error, LocalizedError {
+        case noAudioTrack
+        case failed
+
+        var errorDescription: String? {
+            switch self {
+            case .noAudioTrack: "The file does not contain an audio track."
+            case .failed: "Audio extraction failed."
+            }
+        }
+    }
+}

--- a/Sources/yap/Transcribe.swift
+++ b/Sources/yap/Transcribe.swift
@@ -2,10 +2,11 @@ import ArgumentParser
 import NaturalLanguage
 @preconcurrency import Noora
 import Speech
+import AVFoundation
 
 // MARK: - Transcribe
 
-@MainActor struct Transcribe: AsyncParsableCommand {
+struct Transcribe: AsyncParsableCommand {
     @Option(
         name: .shortAndLong,
         help: "(default: current)",
@@ -40,7 +41,7 @@ import Speech
         help: "Include word-level timestamps in JSON output."
     ) var wordTimestamps: Bool = false
 
-    mutating func run() async throws {
+    func run() async throws {
         guard FileManager.default.fileExists(atPath: inputFile.path) else {
             throw ValidationError("File not found: \(inputFile.path)")
         }
@@ -53,7 +54,7 @@ import Speech
             Noora()
         }
 
-        guard SpeechTranscriber.isAvailable else {
+        if !SpeechTranscriber.isAvailable {
             noora.error(.alert("SpeechTranscriber is not available on this device"))
             throw Error.speechTranscriberNotAvailable
         }
@@ -76,6 +77,7 @@ import Speech
             attributeOptions: outputFormat.needsAudioTimeRange ? [.audioTimeRange] : []
         )
         let modules: [any SpeechModule] = [transcriber]
+        
         let installedLocales = await SpeechTranscriber.installedLocales
         if !installedLocales.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
             if let request = try await AssetInventory.assetInstallationRequest(supporting: modules) {
@@ -86,7 +88,7 @@ import Speech
                         let callAsFunction: (Double) -> Void
                     }
                     let reportProgress = ReportProgress(callAsFunction: progressCallback)
-                    try await withThrowingDiscardingTaskGroup { group in
+                    try await withThrowingTaskGroup(of: Void.self) { group in
                         group.addTask {
                             while !Task.isCancelled, !request.progress.isFinished {
                                 reportProgress.callAsFunction(request.progress.fractionCompleted)
@@ -100,52 +102,86 @@ import Speech
             }
         }
 
+        let asset = AVURLAsset(url: inputFile, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".wav")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        
+        // 1. Extract audio
+        try await noora.progressStep(
+            message: "Extracting audio from file…",
+            successMessage: "Audio extracted",
+            errorMessage: "Failed to extract audio",
+            showSpinner: true
+        ) { _ in
+            try await AudioExtractor.extractAudio(from: asset, to: tempURL)
+        }
+
+        let audioFile = try AVAudioFile(forReading: tempURL)
+        let audioFileDuration = Double(audioFile.length) / audioFile.fileFormat.sampleRate
+
+        actor TranscriptCollector {
+            var transcript: AttributedString = ""
+            func append(_ text: AttributedString) { transcript += text }
+            func getFinalTranscript() -> AttributedString { transcript }
+        }
+        let collector = TranscriptCollector()
+
         let analyzer = SpeechAnalyzer(modules: modules)
-
-        let audioFile = try AVAudioFile(forReading: inputFile)
-        let audioFileDuration: TimeInterval = Double(audioFile.length) / audioFile.processingFormat.sampleRate
-        try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
-
-        var transcript: AttributedString = ""
+        let isPiped = isatty(STDERR_FILENO) != 0
+        let formatPrimary: @Sendable (String) -> String = { noora.format("\(.primary($0))") }
 
         var w = winsize()
         let terminalColumns = if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &w) == 0 {
             max(Int(w.ws_col), 9)
         } else { 64 }
 
-        let formatPrimary: @Sendable (String) -> String = { noora.format("\(.primary($0))") }
-        let useOSCProgress = isatty(STDERR_FILENO) != 0
+        // 2. Transcribe
         try await noora.progressStep(
             message: "Transcribing audio using locale: \"\(locale.identifier)\"…",
             successMessage: "Audio transcribed using locale: \"\(locale.identifier)\"",
             errorMessage: "Failed to transcribe audio using locale: \"\(locale.identifier)\"",
             showSpinner: true
-        ) { @Sendable progressHandler in
-            for try await result in transcriber.results {
-                await MainActor.run {
-                    transcript += result.text
+        ) { progressHandler in
+            // Both the analyzer and the results iterator must run concurrently: the
+            // analyzer drives the transcriber's results stream, so they must interleave.
+            // Using withThrowingTaskGroup ensures that a failure or stall in either task
+            // cancels the other — a standalone unstructured Task means the results loop
+            // hangs forever if the analyzer stops producing output (e.g. at 68%).
+            //
+            // The analyzer runs as a child task; the results loop runs in the group body.
+            // This keeps progressHandler non-escaping (called directly in the body) while
+            // still giving us structured, cooperative concurrency between the two.
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
                 }
-                let progress = min(max(result.resultsFinalizationTime.seconds / audioFileDuration, 0), 1)
-                let percent = Int(progress * 100)
-                if useOSCProgress {
-                    FileHandle.standardError.write(Data("\u{1b}]9;4;1;\(percent)\u{7}".utf8))
+
+                for try await result in transcriber.results {
+                    await collector.append(result.text)
+
+                    let progress = min(max(result.resultsFinalizationTime.seconds / audioFileDuration, 0), 1)
+                    let percent = Int(progress * 100)
+                    if isPiped {
+                        FileHandle.standardError.write(Data("\u{1b}]9;4;1;\(percent)\u{7}".utf8))
+                    }
+                    let preview = String(result.text.characters).trimmingCharacters(in: .whitespaces)
+                    let message = "\(formatPrimary("[\(String(format: "%3d%%", percent))]")) \(preview.prefix(terminalColumns - "⠋ [100%] ".count))"
+                    progressHandler(message)
                 }
-                let preview = String(result.text.characters).trimmingCharacters(in: .whitespaces)
-                let message = "\(formatPrimary("[\(String(format: "%3d%%", percent))]")) \(preview.prefix(terminalColumns - "⠋ [100%] ".count))"
-                progressHandler(message)
+
+                try await group.waitForAll()
             }
         }
-        if useOSCProgress {
+
+        if isPiped {
             FileHandle.standardError.write(Data("\u{1b}]9;4;0\u{7}".utf8))
         }
 
-        let output = outputFormat.text(for: transcript, maxLength: maxLength, locale: locale, wordTimestamps: wordTimestamps)
+        let finalTranscript = await collector.getFinalTranscript()
+        let output = outputFormat.text(for: finalTranscript, maxLength: maxLength, locale: locale, wordTimestamps: wordTimestamps)
+        
         if let outputFile {
-            try output.write(
-                to: outputFile,
-                atomically: false,
-                encoding: .utf8
-            )
+            try output.write(to: outputFile, atomically: false, encoding: .utf8)
             noora.success(.alert("Transcription written to \(outputFile.path)"))
         }
 

--- a/Sources/yap/TranscriptionEngine.swift
+++ b/Sources/yap/TranscriptionEngine.swift
@@ -50,15 +50,39 @@ enum TranscriptionEngine {
         }
 
         let analyzer = SpeechAnalyzer(modules: modules)
-        let audioFile = try AVAudioFile(forReading: file)
-        try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
+        let asset = AVURLAsset(url: file, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
 
-        var transcript: AttributedString = ""
-        for try await result in transcriber.results {
-            transcript += result.text
+        // 1. Extract audio
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".wav")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        try await AudioExtractor.extractAudio(from: asset, to: tempURL)
+
+        let audioFile = try AVAudioFile(forReading: tempURL)
+        
+        actor TranscriptCollector {
+            var transcript: AttributedString = ""
+            func append(_ text: AttributedString) { transcript += text }
+            func getFinalTranscript() -> AttributedString { transcript }
+        }
+        let collector = TranscriptCollector()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await analyzer.start(inputAudioFile: audioFile, finishAfterFile: true)
+            }
+
+            group.addTask {
+                for try await result in transcriber.results {
+                    await collector.append(result.text)
+                }
+            }
+
+            try await group.waitForAll()
         }
 
-        return options.outputFormat.text(for: transcript, maxLength: options.maxLength, locale: options.locale, wordTimestamps: options.wordTimestamps)
+        let finalTranscript = await collector.getFinalTranscript()
+        return options.outputFormat.text(for: finalTranscript, maxLength: options.maxLength, locale: options.locale, wordTimestamps: options.wordTimestamps)
     }
 }
 


### PR DESCRIPTION
Fixes #27

## Summary

Fixes three related issues that cause `yap transcribe` to hang, crash, or fail on real-world video files.

## Changes

### `refactor: extract shared audio transcoding into AudioExtractor`
New `AudioExtractor` module that transcodes audio tracks to 16-bit mono 16 kHz Linear PCM WAV using `AVAssetReader`/`AVAssetWriter`.

- Uses a dedicated **serial** `DispatchQueue` — the previous code used `DispatchQueue.global()` (concurrent), which allowed `requestMediaDataWhenReady` callbacks to fire simultaneously, causing `finishWriting` to be called twice → crash: `NSInternalInconsistencyException`, status 1.
- `SpeechAnalyzer` requires uncompressed PCM; using `AVAssetExportSession` produces AAC/M4A which is rejected with `avfaudio error -50`.

### `fix: resolve transcription hang, crash, and audio format errors`
- Replace unstructured `Task` with `withThrowingTaskGroup` so that a failure in `SpeechAnalyzer` cancels the results loop (and vice versa), preventing the transcription from hanging indefinitely (~68%).
- Extract audio to PCM WAV via `AudioExtractor` before passing to `SpeechAnalyzer`.
- Use a `TranscriptCollector` actor for thread-safe result accumulation.
- Remove `@MainActor` from `Transcribe` and clean up dead error cases.

## Testing

Verified end-to-end on a real-world MP4 file:
```
swift run yap transcribe -l "en-US" ~/Downloads/Q_A_session_for_co-workers_10_April_(Source).mp4
✔︎ Audio extracted [2.5s]
✔︎ Audio transcribed using locale: "en-US" [36.1s]
```