### PR TITLE
Support macOS regional locale overrides

### DIFF
--- a/Sources/yap/Dictate.swift
+++ b/Sources/yap/Dictate.swift
@@ -16,7 +16,7 @@ struct Dictate: AsyncParsableCommand {
         name: .shortAndLong,
         help: "(default: current)",
         transform: Locale.init(identifier:)
-    ) var locale: Locale = .init(identifier: Locale.current.identifier)
+    ) var locale: Locale?
 
     @Flag(
         help: "Replaces certain words and phrases with a redacted form."
@@ -40,8 +40,7 @@ struct Dictate: AsyncParsableCommand {
             throw Transcribe.Error.speechTranscriberNotAvailable
         }
 
-        let supportedLocales = await SpeechTranscriber.supportedLocales
-        guard supportedLocales.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) else {
+        guard let locale = await TranscriptionLocale.resolve(explicitLocale: locale) else {
             throw Transcribe.Error.unsupportedLocale
         }
 

--- a/Sources/yap/Listen.swift
+++ b/Sources/yap/Listen.swift
@@ -18,7 +18,7 @@ struct Listen: AsyncParsableCommand {
         name: .shortAndLong,
         help: "(default: current)",
         transform: Locale.init(identifier:)
-    ) var locale: Locale = .init(identifier: Locale.current.identifier)
+    ) var locale: Locale?
 
     @Flag(
         help: "Replaces certain words and phrases with a redacted form."
@@ -42,8 +42,7 @@ struct Listen: AsyncParsableCommand {
             throw Transcribe.Error.speechTranscriberNotAvailable
         }
 
-        let supportedLocales = await SpeechTranscriber.supportedLocales
-        guard supportedLocales.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) else {
+        guard let locale = await TranscriptionLocale.resolve(explicitLocale: locale) else {
             throw Transcribe.Error.unsupportedLocale
         }
 

--- a/Sources/yap/ListenAndDictate.swift
+++ b/Sources/yap/ListenAndDictate.swift
@@ -19,7 +19,7 @@ struct ListenAndDictate: AsyncParsableCommand {
         name: .shortAndLong,
         help: "(default: current)",
         transform: Locale.init(identifier:)
-    ) var locale: Locale = .init(identifier: Locale.current.identifier)
+    ) var locale: Locale?
 
     @Flag(
         help: "Replaces certain words and phrases with a redacted form."
@@ -51,8 +51,7 @@ struct ListenAndDictate: AsyncParsableCommand {
             throw Transcribe.Error.speechTranscriberNotAvailable
         }
 
-        let supportedLocales = await SpeechTranscriber.supportedLocales
-        guard supportedLocales.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) else {
+        guard let locale = await TranscriptionLocale.resolve(explicitLocale: locale) else {
             throw Transcribe.Error.unsupportedLocale
         }
 

--- a/Sources/yap/Transcribe.swift
+++ b/Sources/yap/Transcribe.swift
@@ -10,7 +10,7 @@ import Speech
         name: .shortAndLong,
         help: "(default: current)",
         transform: Locale.init(identifier:)
-    ) var locale: Locale = .init(identifier: Locale.current.identifier)
+    ) var locale: Locale?
 
     @Flag(
         help: "Replaces certain words and phrases with a redacted form."
@@ -58,9 +58,10 @@ import Speech
             throw Error.speechTranscriberNotAvailable
         }
 
-        let supportedLocales = await SpeechTranscriber.supportedLocales
-        guard supportedLocales.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) else {
-            noora.error(.alert("Locale \"\(locale.identifier)\" is not supported. Supported locales:\n\(supportedLocales.map(\.identifier))"))
+        let requestedLocale = locale ?? .current
+        guard let locale = await TranscriptionLocale.resolve(explicitLocale: locale) else {
+            let supportedLocales = await SpeechTranscriber.supportedLocales
+            noora.error(.alert("Locale \"\(requestedLocale.identifier)\" is not supported. Supported locales:\n\(supportedLocales.map(\.identifier))"))
             throw Error.unsupportedLocale
         }
 

--- a/Sources/yap/TranscriptionEngine.swift
+++ b/Sources/yap/TranscriptionEngine.swift
@@ -5,7 +5,7 @@ import Speech
 
 enum TranscriptionEngine {
     struct Options: Sendable {
-        var locale: Locale = .init(identifier: Locale.current.identifier)
+        var locale: Locale?
         var censor: Bool = false
         var outputFormat: OutputFormat = .txt
         var maxLength: Int = 40
@@ -24,18 +24,18 @@ enum TranscriptionEngine {
             throw TranscriptionError.speechTranscriberNotAvailable
         }
 
-        let supportedLocales = await SpeechTranscriber.supportedLocales
-        guard supportedLocales.contains(where: { $0.identifier(.bcp47) == options.locale.identifier(.bcp47) }) else {
-            throw TranscriptionError.unsupportedLocale(options.locale.identifier)
+        let requestedLocale = options.locale ?? .current
+        guard let locale = await TranscriptionLocale.resolve(explicitLocale: options.locale) else {
+            throw TranscriptionError.unsupportedLocale(requestedLocale.identifier)
         }
 
         for locale in await AssetInventory.reservedLocales {
             await AssetInventory.release(reservedLocale: locale)
         }
-        try await AssetInventory.reserve(locale: options.locale)
+        try await AssetInventory.reserve(locale: locale)
 
         let transcriber = SpeechTranscriber(
-            locale: options.locale,
+            locale: locale,
             transcriptionOptions: options.censor ? [.etiquetteReplacements] : [],
             reportingOptions: [],
             attributeOptions: options.outputFormat.needsAudioTimeRange ? [.audioTimeRange] : []
@@ -43,7 +43,7 @@ enum TranscriptionEngine {
         let modules: [any SpeechModule] = [transcriber]
 
         let installedLocales = await SpeechTranscriber.installedLocales
-        if !installedLocales.contains(where: { $0.identifier(.bcp47) == options.locale.identifier(.bcp47) }) {
+        if !installedLocales.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
             if let request = try await AssetInventory.assetInstallationRequest(supporting: modules) {
                 try await request.downloadAndInstall()
             }
@@ -59,7 +59,7 @@ enum TranscriptionEngine {
             transcript += result.text
         }
 
-        return options.outputFormat.text(for: transcript, maxLength: options.maxLength, locale: options.locale, wordTimestamps: options.wordTimestamps)
+        return options.outputFormat.text(for: transcript, maxLength: options.maxLength, locale: locale, wordTimestamps: options.wordTimestamps)
     }
 }
 

--- a/Sources/yap/TranscriptionEngine.swift
+++ b/Sources/yap/TranscriptionEngine.swift
@@ -5,7 +5,7 @@ import Speech
 
 enum TranscriptionEngine {
     struct Options: Sendable {
-        var locale: Locale?
+        var locale: Locale? = nil
         var censor: Bool = false
         var outputFormat: OutputFormat = .txt
         var maxLength: Int = 40

--- a/Sources/yap/TranscriptionLocale.swift
+++ b/Sources/yap/TranscriptionLocale.swift
@@ -1,0 +1,14 @@
+import Speech
+
+enum TranscriptionLocale {
+    static func resolve(explicitLocale: Locale?) async -> Locale? {
+        guard let explicitLocale else {
+            return await SpeechTranscriber.supportedLocale(equivalentTo: .current)
+        }
+
+        let supportedLocales = await SpeechTranscriber.supportedLocales
+        return supportedLocales.first {
+            $0.identifier(.bcp47) == explicitLocale.identifier(.bcp47)
+        }
+    }
+}


### PR DESCRIPTION
macOS allows language and region to be configured independently which can result in locale identifiers that `yap` does not currently support.

For example:
- English (UK) with Germany as the region produces `en_DE`.
- English (US) with Germany as the region produces `en_US@rg=dezzzz`.

Since yap required an exact match for supported locales these valid system configurations would fail to transcribe.

This change uses `SpeechTranscriber.supportedLocale(equivalentTo:)` to provide an equivalent locale when invoked with the default system locale. Locales that are provided by the user via an argument continue to require an exact match in order to avoid being silently replaced by another variant.